### PR TITLE
Fix AutoGen tool and team configuration for latest API

### DIFF
--- a/my_agent/team-config.json
+++ b/my_agent/team-config.json
@@ -124,9 +124,7 @@
                         "work_dir": ".coding",
                         "functions_module": "functions"
                       }
-                    },
-                    "description": "Execute Python code blocks.",
-                    "name": "Python_Code_Execution_Tool"
+                    }
                   }
                 }
               ]
@@ -175,7 +173,6 @@
       }
     },
     "selector_prompt": "You are coordinating a team that writes tests for Python code by selecting the member who will speak/act next. The following team member roles are available:\n {roles}.\n test_writing_assistant writes tests in Python .\n verification_assistant evaluates the written tests, checking that they run and work correctly (choose this role if you need to check/evaluate the tests that the test_writing_assistant has written). \n The summary_agent provides the user with a detailed summary of the study in the form of a report.\n\n\n\n Given the current context, select the most appropriate next presenter.\n You should ONLY select the summary_agent role if the tests have been written and checked and it is time to create a report.\n\n\n\n Your selection should be based on: \n 1. Current stage of test writing and validation.\n 2. Last speaker's findings or suggestions\n 3. Need for test verification vs need for new information.\n Read the following conversation. Then select the next role from {participants} to play. Return only the role.\n\n\n {history}\n\n\n Read the above conversation. Then select the next role from {participants} to play. ONLY RETURN THE ROLE.",
-    "allow_repeated_speaker": true,
     "max_selector_attempts": 3,
     "emit_team_events": false
   }


### PR DESCRIPTION
## Summary
- remove deprecated allow_repeated_speaker option and add selector configuration for `RoundRobinGroupChat`
- drop unsupported `allow_repeated_speaker` field from team JSON

## Testing
- `python -m py_compile my_agent/autogen_agent.py`
- `python my_agent/autogen_agent.py "Write tests for a fibonacci function" my_agent/sample_project --log-file my_agent/conversation.log` *(fails: ModuleNotFoundError: No module named 'autogen_core')*
- `python -m pip install autogen-agentchat autogen-core autogen-ext` *(fails: Could not find a version that satisfies the requirement autogen-agentchat; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689dd401ca7083208c7a500ab8b9845b