### PR TITLE
feat: add configurable model settings

### DIFF
--- a/my_agent/config.py
+++ b/my_agent/config.py
@@ -1,0 +1,14 @@
+import os
+from autogen_core.models import ModelInfo
+
+MODEL = os.environ.get("OPENAI_MODEL", "openai/Devstral")
+BASE_URL = os.environ.get("OPENAI_BASE_URL", "tmp")
+API_KEY = os.environ.get("OPENAI_API_KEY", "tmp")
+
+MODEL_INFO = ModelInfo(
+    vision=False,
+    function_calling=False,
+    json_output=False,
+    family="mistral",
+    structured_output=True,
+)


### PR DESCRIPTION
## Summary
- load model, base URL and API key from a dedicated config module
- include ModelInfo metadata for OpenAI client
- remove unsupported selector prompt from RoundRobinGroupChat

## Testing
- `python my_agent/autogen_agent.py "Write tests for a fibonacci function" my_agent/sample_project --log-file my_agent/conversation.log` *(fails: ModuleNotFoundError: No module named 'autogen_core')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e211a8a9c832096afbe50e1eaa656